### PR TITLE
adds error examples

### DIFF
--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -1,5 +1,61 @@
 # Errors
 
+> 400 Bad Request Example Error Response:
+
+```json
+{
+  "statusCode": 400,
+  "error": "Bad Request",
+  "message": "vin is required",
+  "validation": {
+    "errors": [
+      {
+        "key": [
+          "vin"
+        ],
+        "path": [
+          "vin"
+        ],
+        "message": "vin is required",
+        "type": "any",
+        "constraint": "required",
+        "label": "vin"
+      }
+    ]
+  }
+}
+```
+
+> 401 Auth Token Example Error Response:
+
+```json
+{
+  "statusCode": 401,
+  "error": "Unauthorized",
+  "message": "The provided token has expired."
+}
+```
+
+> 403 Forbidden Example Error Response:
+
+```json
+{
+  "statusCode": 403,
+  "error": "Forbidden",
+  "message": "This claim is not available during testing."
+}
+```
+
+> 500 Internal Server Error Example Error Response:
+
+```json
+{
+  "statusCode": 500,
+  "error": "Internal Server Error",
+  "message": "An internal server error occurred"
+}
+```
+
 Our Vendor API uses the following error codes:
 
 Error Code | Meaning

--- a/source/includes/_letter_of_guarantee.md
+++ b/source/includes/_letter_of_guarantee.md
@@ -13,6 +13,16 @@
 
 > This route will throw a `400: BAD REQUEST` if it fails due to lack of information on a claim.
 
+> Create Letter of Guarantee Request Example Error Response:
+
+```json
+{
+  "statusCode": 400,
+  "error": "Bad Request",
+  "message": "Claim is missing one or more required documents: 'settlement breakdown' & 'valuation report'"
+}
+```
+
 This route will create a letter of guarantee request on a claim. The letter of guarantee request can be added at any time, but will fail when:
 
 - IF documents with type `settlement breakdown` and `valuation report` are not available (or a document with type `settlement breakdown & valuation report`)
@@ -39,6 +49,16 @@ claimId | The LossExpress UUID associated with the claim
 ```
 
 > This route will throw a `404: NOT FOUND` if a Letter of Guarantee request is not available on the claim.
+
+> Cancel Letter of Guarantee Request Example Error Response:
+
+```json
+{
+  "statusCode": 404,
+  "error": "Not Found",
+  "message": "Letter of Guarantee does not exist for this claim."
+}
+```
 
 This route will cancel a letter of guarantee request on a claim. This route will return an error if a letter of guarantee request has not been added on a claim yet.
 
@@ -67,6 +87,29 @@ claimId | The LossExpress UUID associated with the claim
 
 > This route will throw a `400: BAD REQUEST` if it fails due to lack of information on a claim.
 
+> This route will throw a `404: NOT FOUND` if a Letter of Guarantee request is not available on the claim.
+
+
+> Refresh Letter of Guarantee Request Example Error Responses:
+
+ ```json
+{
+  "statusCode": 404,
+  "error": "Not Found",
+  "message": "Letter of Guarantee does not exist for this claim."
+}
+```
+
+
+```json
+{
+  "statusCode": 400,
+  "error": "Bad Request",
+  "message": "Claim is missing one or more required documents: 'settlement breakdown' & 'valuation report'"
+}
+```
+
+
 <aside class="notice">
 This route is not currently available, but will be available in a future release of LossExpress xAPI.
 </aside>
@@ -74,6 +117,7 @@ This route is not currently available, but will be available in a future release
 This route will refresh an existing letter of guarantee request on a claim, notifying our system that vital information has changed and additional work may be required. The letter of guarantee request can be added at any time, but will fail when:
 
 - IF documents with type `settlement breakdown` and `valuation report` are not available (or a document with type `settlement breakdown & valuation report`)
+- IF a letter of guarantee request does not exist on a claim
 
 ### HTTP Request
 

--- a/source/includes/_orders.md
+++ b/source/includes/_orders.md
@@ -1,7 +1,9 @@
 # Orders
 
 ## Fetch Order Types
+
 > Fetch Order Types Request Example Response Body 
+
 ```json
 {
   "orderTypes": ["...array of current order types"],
@@ -18,6 +20,7 @@ This route returns an array of strings, which consist of the current types of or
 ## Create Order(s) Request
 
 > Create Order(s) Request Example Response Body:
+
 ```json
 {
   "claimId": "c30ae9da-9222-4de5-81fe-fe1ac590fa0f",
@@ -59,6 +62,7 @@ types | An array containing strings with types of orders to be created | Y
 ## Cancel Order(s) Request
 
 > Cancel Order(s) Request Example Response Body:
+
 ```json
 {
   "claimId": "c30ae9da-9222-4de5-81fe-fe1ac590fa0f",

--- a/source/includes/_payoff_data.md
+++ b/source/includes/_payoff_data.md
@@ -12,6 +12,16 @@
 
 > This route will throw a `400: BAD REQUEST` if the payoff request fails due to missing information on the claim.
 
+> Create Payoff Request Example Error Response:
+
+```json
+{
+  "statusCode": 400,
+  "error": "Bad Request",
+  "message": "Claim is missing one or more required documents: 'settlement breakdown' & 'valuation report'"
+}
+```
+
 This route will create a payoff request on a claim. The request will fail when:
 
 - IF documents with type `settlement breakdown` and `valuation report` are not available (or a document with type `settlement breakdown & valuation report`)
@@ -39,6 +49,16 @@ claimId | The LossExpress UUID associated with the claim
 
 > This route will throw a `404: NOT FOUND` if a Payoff request is not available on the claim.
 
+> Cancel Payoff Request Example Error Response:
+
+```json
+{
+  "statusCode": 404,
+  "error": "Not Found",
+  "message": "A payoff request does not exist for this claim."
+}
+```
+
 This route will cancel a payoff request on a claim. This route will return an error if a payoff request has not been added on a claim yet.
 
 This route will not return an error if a payoff request has been previously cancelled or completed.
@@ -65,6 +85,28 @@ claimId | The LossExpress UUID associated with the claim
 
 > This route will throw a `400: BAD REQUEST` if the payoff request fails due to missing information on the claim.
 
+> This route will throw a `404: NOT FOUND` if a payoff request is not available on the claim.
+
+
+> Refresh Payoff Request Example Error Responses:
+
+
+```json
+{
+  "statusCode": 404,
+  "error": "Not Found",
+  "message": "A payoff request does not exist for this claim."
+}
+```
+
+```json
+{
+  "statusCode": 400,
+  "error": "Bad Request",
+  "message": "Claim is missing one or more required documents: 'settlement breakdown' & 'valuation report'"
+}
+```
+
 <aside class="notice">
 This route is not currently available, but will be available in a future release of LossExpress xAPI.
 </aside>
@@ -72,6 +114,7 @@ This route is not currently available, but will be available in a future release
 This route will refresh a payoff request on a claim, notifying our system that vital information has changed and additional work may be required. The request will fail when:
 
 - IF documents with type `settlement breakdown` and `valuation report` are not available (or a document with type `settlement breakdown & valuation report`)
+- IF a payoff request does not exist on the claim
 
 ### HTTP Request
 

--- a/source/includes/_settlement_counters.md
+++ b/source/includes/_settlement_counters.md
@@ -13,6 +13,16 @@
 
 > This route will throw a `404: NOT FOUND` if there are no settlement counters present on the claim.
 
+> Example Error Response:
+
+```json
+{
+  "statusCode": 404,
+  "error": "Not Found",
+  "message": "A settlement counter does not exist for this claim."
+}
+```
+
 This route allows for either accepting or disputing a settlement counter presented by a lender.
 
 To accept a counter, you must send a new settlement breakdown document. To dispute a counter, you must set `dispute` to true and provide a `reasonForDispute`.


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Adds error examples to docs, including vendor refreshes.