### PR TITLE
fix/documents-url-route

### DIFF
--- a/source/includes/_documents.md
+++ b/source/includes/_documents.md
@@ -52,4 +52,4 @@ This route allows for fetching documents from our system as PDFs. Any activity t
 
 ### HTTP Request
 
-`GET https://xapi.lossexpress.com/claims/documents/{documentId}`
+`GET https://xapi.lossexpress.com/documents/{documentId}`


### PR DESCRIPTION
now displays the correct url for fetching documents