### PR TITLE
Indicate that call-made and document-sent-to-lender have been depreci…

### DIFF
--- a/source/includes/_activity_feed.md
+++ b/source/includes/_activity_feed.md
@@ -237,6 +237,10 @@ This activity type will appear in the feed whenever an account number is viewed 
 
 This activity type will appear in the feed whenever a call was made on behalf of the carrier by LossExpress.
 
+<aside class="warning">
+  This activity has been deprecated in favor of the newer <a href="https://vendor-docs.lossexpress.com/#request-pending-lender-contacted">request-pending-lender-contacted</a> activity.
+</aside>
+
 ## claim-created
 
 > claim-created example object
@@ -474,6 +478,10 @@ Documents that will not trigger this activity:
 ```
 
 This activity type is added to the feed whenever a document is sent by LossExpress to the lender for a particular claim. The <code>documentUrl</code> contains a link to the document that was sent to the lender.
+
+<aside class="warning">
+  This activity has been deprecated in favor of the newer <a href="https://vendor-docs.lossexpress.com/#request-pending-lender-contacted">request-pending-lender-contacted</a> activity.
+</aside>
 
 ## letter-of-guarantee-added
 


### PR DESCRIPTION
This PR adds a warning to the `call-made` and `document-sent-to-lender` activity types stating they have been depreciated in favor of the newer `request-pending-lender-contacted` activity type. This will need to be merged AFTER the issues related to [246-Create new activity "Request-Pending-Lender-Contacted" and introduce the activity type to ODA AND Faxes AND Calls](https://app.zenhub.com/workspaces/xlien-product-61ba078a3bc14c0017091daf/issues/fastlane-llc/external-api/246) have been merged.